### PR TITLE
Fix anonymous sign-in, add linkToCurrentSession, persist token on phone verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.15.0
+
+- `PhoneNumberPlugin.verify` now persists the returned token via `TokenStore`
+- `BetterAuthClient` auto-attaches `SetAuthTokenHeaderInterceptor` on the shared Dio instance
+
 ### 0.14.0
 
 - Added username plugin with sign-in support

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -15,7 +15,7 @@ await client.phoneNumber.sendOTP(
 ```
 
 ### Verify Phone Number
-Verifies the phone number using the OTP sent to the user's phone.
+Verifies the phone number using the OTP sent to the user's phone. On success, the returned session token is automatically persisted via your `TokenStore`, so subsequent authenticated requests will include it through the client's auth interceptor — you don't need to call `tokenStore.saveToken` yourself.
 
 ```dart
 final response = await client.phoneNumber.verifyPhoneNumber(

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -35,6 +35,7 @@ class CatPlugin extends BasePlugin<PremiumUser> {
 
 class InMemoryTokenStore extends TokenStore {
   String? _token;
+  String? _adminToken;
 
   @override
   Future<String> getToken() {
@@ -44,6 +45,17 @@ class InMemoryTokenStore extends TokenStore {
   @override
   Future<void> saveToken(String? token) {
     _token = token;
+    return Future.value();
+  }
+
+  @override
+  Future<String> getAdminToken() {
+    return Future.value(_adminToken ?? "");
+  }
+
+  @override
+  Future<void> saveAdminToken(String? token) {
+    _adminToken = token;
     return Future.value();
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -39,7 +39,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.10"
+    version: "0.12.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: e55636ed79578b9abca5fecf9437947798f5ef7456308b5cb85720b793eac92f
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "82.0.0"
+    version: "99.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "904ae5bb474d32c38fb9482e2d925d5454cda04ddd0e55d2e6826bc72f6ba8c0"
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.5"
+    version: "12.1.0"
   args:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   better_auth_client:
     dependency: "direct main"
     description:
@@ -76,34 +76,34 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "802bd084fb82e55df091ec8ad1553a7331b61c08251eef19a508b6f3f3a9858d"
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.1"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   dio:
     dependency: transitive
     description:
       name: dio
-      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0+1"
+    version: "5.9.2"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
@@ -152,22 +152,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.11.0"
   lints:
     dependency: "direct dev"
     description:
@@ -188,18 +180,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: df0c643f44ad098eb37988027a8e2b2b5a031fd3977f06bbfd3a76637e8df739
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.2"
   mime:
     dependency: transitive
     description:
@@ -236,10 +228,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   pub_semver:
     dependency: transitive
     description:
@@ -300,10 +292,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -340,26 +332,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: f1665eeffe3b6b193548b5f515e8d1b54ccd9a6e0e7721a417e134e7ed7f06a1
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6c7653816b1c938e121b69ff63a33c9dc68102b65a5fb0a5c0f9786256ed33e6"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.5"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "3caa7c3956b366643b2dedecff764cc32030317b2a15252aed845570df6bcc0f"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.9"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -372,18 +364,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "046d3928e16fa4dc46e8350415661755ab759d9fc97fc21b5ab295f71e4f0499"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "15.1.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.1"
   web:
     dependency: transitive
     description:
@@ -425,4 +417,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.2 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"

--- a/lib/plugins/phone_number.dart
+++ b/lib/plugins/phone_number.dart
@@ -49,7 +49,9 @@ class PhoneNumberPlugin<T extends User> extends BasePlugin<T> {
           "updatePhoneNumber": updatePhoneNumber,
         },
       );
-      return UserAndTokenResponse.fromJson(response.data);
+      final parsed = UserAndTokenResponse.fromJson(response.data);
+      await tokenStore.saveToken(parsed.token);
+      return parsed;
     } catch (e) {
       final message = getErrorMessage(e);
       if (message == null) rethrow;

--- a/lib/src/auth/signin.dart
+++ b/lib/src/auth/signin.dart
@@ -94,9 +94,15 @@ class Signin<T extends User> {
   /// [provider] The social provider to use
   ///
   /// [idToken] The ID token to use for the social provider. Usually applicable to Apple and Google if you prefer to use native packages to handle the sign in process.
-  Future<UserAndTokenResponse> socialWithIdToken({required String provider, required IdToken idToken}) async {
+  ///
+  /// [linkToCurrentSession] If true, sends the current bearer token with the request to link the social account to the current anonymous user. Used for anonymous account linking.
+  Future<UserAndTokenResponse> socialWithIdToken({
+    required String provider,
+    required IdToken idToken,
+    bool linkToCurrentSession = false,
+  }) async {
     final body = {"provider": provider, "idToken": idToken.toJson()};
-    final baseOptions = await _getOptions(isTokenRequired: false);
+    final baseOptions = await _getOptions(isTokenRequired: linkToCurrentSession);
     baseOptions.headers ??= {};
     if (_scheme != null) {
       baseOptions.headers!["expo-origin"] = _scheme;

--- a/lib/src/auth/signin.dart
+++ b/lib/src/auth/signin.dart
@@ -112,33 +112,6 @@ class Signin<T extends User> {
     }
   }
 
-  /// Link an anonymous account with a social provider using id token
-  ///
-  /// This method sends the current bearer token with the request so Better Auth
-  /// knows the user is logged in as anonymous and can link the accounts.
-  ///
-  /// [provider] The social provider to use (e.g., 'google', 'apple')
-  ///
-  /// [idToken] The ID token from the social provider
-  Future<UserAndTokenResponse> linkSocialWithIdToken({required String provider, required IdToken idToken}) async {
-    final body = {"provider": provider, "idToken": idToken.toJson()};
-    // Use isTokenRequired: true to send the current bearer token
-    final baseOptions = await _getOptions(isTokenRequired: true);
-    baseOptions.headers ??= {};
-    if (_scheme != null) {
-      baseOptions.headers!["expo-origin"] = _scheme;
-    }
-    try {
-      final res = await _dio.post('/sign-in/social', data: body, options: baseOptions);
-      _setToken(res.data['token']);
-      return UserAndTokenResponse.fromJson(res.data);
-    } catch (e) {
-      final message = getErrorMessage(e);
-      if (message == null) rethrow;
-      throw message;
-    }
-  }
-
   /// Sign in anonymously
   Future<UserAndTokenResponse> anonymous() async {
     try {

--- a/lib/src/auth/signin.dart
+++ b/lib/src/auth/signin.dart
@@ -113,10 +113,11 @@ class Signin<T extends User> {
   }
 
   /// Sign in anonymously
-  Future<SessionResponse<T>> anonymous() async {
+  Future<UserAndTokenResponse> anonymous() async {
     try {
       final response = await _dio.post("/sign-in/anonymous", options: await _getOptions(isTokenRequired: false));
-      return SessionResponse.fromJson(response.data, _fromJsonUser);
+      _setToken(response.data['token']);
+      return UserAndTokenResponse.fromJson(response.data);
     } catch (e) {
       final message = getErrorMessage(e);
       if (message == null) rethrow;

--- a/lib/src/auth/signin.dart
+++ b/lib/src/auth/signin.dart
@@ -112,6 +112,33 @@ class Signin<T extends User> {
     }
   }
 
+  /// Link an anonymous account with a social provider using id token
+  ///
+  /// This method sends the current bearer token with the request so Better Auth
+  /// knows the user is logged in as anonymous and can link the accounts.
+  ///
+  /// [provider] The social provider to use (e.g., 'google', 'apple')
+  ///
+  /// [idToken] The ID token from the social provider
+  Future<UserAndTokenResponse> linkSocialWithIdToken({required String provider, required IdToken idToken}) async {
+    final body = {"provider": provider, "idToken": idToken.toJson()};
+    // Use isTokenRequired: true to send the current bearer token
+    final baseOptions = await _getOptions(isTokenRequired: true);
+    baseOptions.headers ??= {};
+    if (_scheme != null) {
+      baseOptions.headers!["expo-origin"] = _scheme;
+    }
+    try {
+      final res = await _dio.post('/sign-in/social', data: body, options: baseOptions);
+      _setToken(res.data['token']);
+      return UserAndTokenResponse.fromJson(res.data);
+    } catch (e) {
+      final message = getErrorMessage(e);
+      if (message == null) rethrow;
+      throw message;
+    }
+  }
+
   /// Sign in anonymously
   Future<UserAndTokenResponse> anonymous() async {
     try {

--- a/lib/src/auth/signup.dart
+++ b/lib/src/auth/signup.dart
@@ -29,7 +29,13 @@ class Signup<T extends User> {
     try {
       final response = await _dio.post(
         "/sign-up/email",
-        data: {"email": email, "password": password, "name": name, "image": image, "username": username},
+        data: {
+          "email": email,
+          "password": password,
+          "name": name,
+          if (image != null) "image": image,
+          if (username != null) "username": username,
+        },
       );
       final body = response.data;
       _setToken(body["token"]);

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -127,6 +127,7 @@ class BetterAuthClient<T extends User> {
 
   void _internal() {
     _dio = generateDioClient(baseUrl);
+    _dio.interceptors.add(SetAuthTokenHeaderInterceptor(store: tokenStore));
     signUp = Signup<T>(dio: _dio, setToken: tokenStore.saveToken, fromJsonUser: _fromJsonUser);
     signIn = Signin<T>(
       dio: _dio,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: better_auth_client
 description: "A client package for Better Auth. Allow you use Better Auth in your Dart applications"
-version: 0.14.1
+version: 0.15.0
 repository: https://github.com/phantomknight287/better_auth_client
 
 environment:

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -3,6 +3,7 @@ import 'package:test/test.dart';
 
 class InMemoryTokenStore extends TokenStore {
   String? _token;
+  String? _adminToken;
 
   @override
   Future<String> getToken() {
@@ -12,6 +13,17 @@ class InMemoryTokenStore extends TokenStore {
   @override
   Future<void> saveToken(String? token) {
     _token = token;
+    return Future.value();
+  }
+
+  @override
+  Future<String> getAdminToken() {
+    return Future.value(_adminToken ?? "");
+  }
+
+  @override
+  Future<void> saveAdminToken(String? token) {
+    _adminToken = token;
     return Future.value();
   }
 }


### PR DESCRIPTION
## Summary

This PR bundles a few fixes and improvements around anonymous sign-in, social account linking, and phone-number auth token handling.

### Fixes

- **Anonymous sign-in return type** — `/sign-in/anonymous` returns `{ token, user }`, not `{ session, user }`. Updated the client to use `UserAndTokenResponse`, and the token is now correctly persisted via `tokenStore`.
- **Phone number verification** — `PhoneNumberPlugin.verify()` now saves the returned token via `tokenStore` so subsequent calls are authenticated.
- **Auth header interceptor** — `BetterAuthClient` now wires `SetAuthTokenHeaderInterceptor` on its shared Dio instance, so requests automatically include the stored token.

### Features

- **`linkToCurrentSession` parameter on `socialWithIdToken`** — lets an anonymous (or any logged-in) user link a social identity to their current session instead of creating a new one. Maps to Better Auth's server-side account linking flow.

## Files Changed

- `lib/src/auth/signin.dart` — anonymous return type + `linkToCurrentSession` param
- `lib/src/auth/signup.dart` — (merge hygiene with upstream username plugin fields)
- `lib/plugins/phone_number.dart` — persist token after verification
- `lib/src/client.dart` — attach auth interceptor
- `example/lib/example.dart`, `test/main_test.dart` — usage examples and tests

## Test plan

- [ ] Anonymous sign-in returns a valid token and sets the session
- [ ] Calling `socialWithIdToken(linkToCurrentSession: true)` while anonymous links the provider account to the existing session (no new user created)
- [ ] `phoneNumber.verify()` stores the token so the next authenticated call succeeds without manually passing it
- [ ] Existing flows (email/password signup, social sign-in without linking) still pass
