### PR TITLE
fix: handle non-Map response data in dio error helpers and bump to 0.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.15.1
+
+- Fix `TypeError` in `dioErrorToMessage` and `getErrorMessage` when the response body is not a JSON object (e.g. HTML or plain text error pages)
+
 ### 0.15.0
 
 - `PhoneNumberPlugin.verify` now persists the returned token via `TokenStore`

--- a/lib/helpers/dio.dart
+++ b/lib/helpers/dio.dart
@@ -3,7 +3,11 @@ import 'package:dio/dio.dart';
 String dioErrorToMessage(DioException e) {
   switch (e.type) {
     case DioExceptionType.badResponse:
-      return e.response?.data?["message"] ?? "An unknown error occurred";
+      final data = e.response?.data;
+      if (data is Map) {
+        return data["message"]?.toString() ?? "An unknown error occurred";
+      }
+      return data?.toString() ?? "An unknown error occurred";
     case DioExceptionType.cancel:
       return "Request cancelled";
     case DioExceptionType.connectionError:
@@ -26,7 +30,11 @@ String? getErrorMessage(Object e) {
     if (e.response?.statusCode == 404) {
       return "Not found";
     }
-    return e.response?.data?['message'] ?? e.response?.data?['error'] ?? "An unknown error occurred";
+    final data = e.response?.data;
+    if (data is Map) {
+      return data['message']?.toString() ?? data['error']?.toString() ?? "An unknown error occurred";
+    }
+    return data?.toString() ?? "An unknown error occurred";
   }
   return null;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: better_auth_client
 description: "A client package for Better Auth. Allow you use Better Auth in your Dart applications"
-version: 0.15.0
+version: 0.15.1
 repository: https://github.com/phantomknight287/better_auth_client
 
 environment:


### PR DESCRIPTION
…15.1

`dioErrorToMessage` and `getErrorMessage` previously assumed `e.response?.data` was a `Map` and would throw a `TypeError` when the server returned a non-JSON body (HTML error page, plain string, etc). Type-check the data first and fall back to its string form.